### PR TITLE
Use Colors as a repeated pattern rather than 1:1.

### DIFF
--- a/src/FontStashSharp/SpriteFontBase.IFontStashRenderer.cs
+++ b/src/FontStashSharp/SpriteFontBase.IFontStashRenderer.cs
@@ -54,7 +54,7 @@ namespace FontStashSharp
 			{
 				int codepoint;
 				Color color;
-				if (!source.GetNextCodepoint(out codepoint, out color))
+				if (!source.GetNextCodepoint(out codepoint))
 					break;
 
 				if (codepoint == '\n')
@@ -83,6 +83,8 @@ namespace FontStashSharp
 
 				if (!glyph.IsEmpty)
 				{
+					color = source.GetNextColor();
+					
 					var p = pos + new Vector2(glyph.RenderOffset.X, glyph.RenderOffset.Y);
 					p = p.Transform(ref transformation);
 

--- a/src/FontStashSharp/SpriteFontBase.IFontStashRenderer2.cs
+++ b/src/FontStashSharp/SpriteFontBase.IFontStashRenderer2.cs
@@ -60,7 +60,7 @@ namespace FontStashSharp
 			{
 				int codepoint;
 				Color color;
-				if (!source.GetNextCodepoint(out codepoint)
+				if (!source.GetNextCodepoint(out codepoint))
 					break;
 
 				if (codepoint == '\n')

--- a/src/FontStashSharp/SpriteFontBase.IFontStashRenderer2.cs
+++ b/src/FontStashSharp/SpriteFontBase.IFontStashRenderer2.cs
@@ -60,7 +60,7 @@ namespace FontStashSharp
 			{
 				int codepoint;
 				Color color;
-				if (!source.GetNextCodepoint(out codepoint, out color))
+				if (!source.GetNextCodepoint(out codepoint)
 					break;
 
 				if (codepoint == '\n')
@@ -88,6 +88,8 @@ namespace FontStashSharp
 
 				if (!glyph.IsEmpty)
 				{
+					 color = source.GetNextColor();
+					
 #if MONOGAME || FNA || STRIDE
 					var textureSize = new Point(glyph.Texture.Width, glyph.Texture.Height);
 					var setColor = color;

--- a/src/FontStashSharp/TextColorSource.cs
+++ b/src/FontStashSharp/TextColorSource.cs
@@ -67,6 +67,7 @@ namespace FontStashSharp
 
 		public bool IsNull => TextSource.IsNull;
 
+		[System.Obsolete("Possible phase out.")]
 		public bool GetNextCodepoint(out int codepoint, out Color color)
 		{
 			color = Color.Transparent;
@@ -86,6 +87,28 @@ namespace FontStashSharp
 			}
 
 			return true;
+		}
+		
+		public bool GetNextCodepoint(out int codepoint)
+		{
+			return TextSource.GetNextCodepoint(out codepoint);
+		}
+		
+		public Color GetNextColor()
+		{
+			var color = Color.Transparent;
+			
+			if (SingleColor != null)
+			{
+				color = SingleColor.Value;
+			}
+			else
+			{
+				color = Colors[ColorPosition % Colors.Length];
+				++ColorPosition;
+			}
+			
+			return color;
 		}
 	}
 }


### PR DESCRIPTION
I'm proposing a change to how drawing text with multiple colors works. While issue 
 https://github.com/FontStashSharp/FontStashSharp/issues/29 is working as currently intended, I think it defies expectations somewhat and pretty much requires the making of a custom Color[] function to work sanely.

The first part of the change is to make the array repeat after Colors.Length is exhausted inside TextColorSource.

**Old**
`color = Colors[ColorPosition];`

**New**
`color = Colors[ColorPosition % Colors.Length];`

This new code will should only error out if the Length is 0, which would be an error in any situation. This code itself would also would probably not break any custom functions anyone has made to make a custom Color[] function. **If nothing else, I think this change would be useful and provide expected results.**

![1](https://user-images.githubusercontent.com/36146858/179365101-baa68542-2635-4f34-ad38-39e488939b7d.png)

This produces

![2](https://user-images.githubusercontent.com/36146858/179365562-6a0c4302-f583-418d-813d-f64155a58895.png)

However, I _personally_ don't feel this is quite what would be expected either. Notice the o in hello and the W in world are both green. This is because with the repeating pattern, the position of the space between the two words is receiving the red. I think most expectations would be that the W would be red. 

To change this, I modified TextSource to include decoupled functions for getting the next codepoint and getting the next color. I modified the two rendering classes to use these two methods and to only advance the color if the resulting glyph is not empty.

This produces

![3](https://user-images.githubusercontent.com/36146858/179365780-522c7a20-cbc6-43e3-9d2e-57a9b2ee15fc.png)

However, this almost certainly will break custom Color[] functions people have made to achieve the same result, assuming they inserted their own check for spaces or empty glyphs and added extra colors to their arrays to compensate. Those checks and compensations would need to be removed. Since recent and future versions of FSS seem to be open to some API changes, I think this would be a minor annoyance.

It is my opinion that this change would reduce the likelihood of errors from mismatched string and array lengths that result either from custom functions or hard coding. I also think that it would reduce the workload to achieve the effect that I think is probably the first expectation of this feature.