### PR TITLE
Allow customization of FontAtlas in subclassed FontSystem

### DIFF
--- a/src/FontStashSharp/FontSystem.cs
+++ b/src/FontStashSharp/FontSystem.cs
@@ -161,6 +161,30 @@ namespace FontStashSharp
 			return g;
 		}
 
+		protected virtual FontAtlas CreateNewAtlas(int textureWidth, int textureHeight)
+		{
+			Texture2D existingTexture = null;
+			if (ExistingTexture != null && Atlases.Count == 0)
+			{
+				existingTexture = ExistingTexture;
+			}
+
+			FontAtlas _newAtlas = new FontAtlas(textureWidth, textureHeight, 256, existingTexture);
+		
+			// If existing texture is used, mark existing used rect as used
+			if (existingTexture != null && !ExistingTextureUsedSpace.IsEmpty)
+			{
+				if (!_newAtlas.AddSkylineLevel(0, ExistingTextureUsedSpace.X, ExistingTextureUsedSpace.Y, ExistingTextureUsedSpace.Width, ExistingTextureUsedSpace.Height))
+				{
+					throw new Exception(string.Format("Unable to specify existing texture used space: {0}", ExistingTextureUsedSpace));
+				}
+
+				// TODO: Clear remaining space
+			}
+
+			return _newAtlas;
+		}
+
 #if MONOGAME || FNA || STRIDE
 		private FontAtlas GetCurrentAtlas(GraphicsDevice device, int textureWidth, int textureHeight)
 #else
@@ -169,23 +193,11 @@ namespace FontStashSharp
 		{
 			if (_currentAtlas == null)
 			{
-				Texture2D existingTexture = null;
-				if (ExistingTexture != null && Atlases.Count == 0)
+				_currentAtlas = CreateNewAtlas(textureWidth, textureHeight);
+
+				if (_currentAtlas == null)
 				{
-					existingTexture = ExistingTexture;
-				}
-
-				_currentAtlas = new FontAtlas(textureWidth, textureHeight, 256, existingTexture);
-
-				// If existing texture is used, mark existing used rect as used
-				if (existingTexture != null && !ExistingTextureUsedSpace.IsEmpty)
-				{
-					if (!_currentAtlas.AddSkylineLevel(0, ExistingTextureUsedSpace.X, ExistingTextureUsedSpace.Y, ExistingTextureUsedSpace.Width, ExistingTextureUsedSpace.Height))
-					{
-						throw new Exception(string.Format("Unable to specify existing texture used space: {0}", ExistingTextureUsedSpace));
-					}
-
-					// TODO: Clear remaining space
+					throw new Exception("New font atlas is null.");
 				}
 
 				Atlases.Add(_currentAtlas);

--- a/src/FontStashSharp/FontSystem.cs
+++ b/src/FontStashSharp/FontSystem.cs
@@ -161,22 +161,22 @@ namespace FontStashSharp
 			return g;
 		}
 
-		protected virtual FontAtlas CreateNewAtlas(int textureWidth, int textureHeight)
+		public static FontAtlas CreateNewAtlas(FontSystem fontSystem, int textureWidth, int textureHeight)
 		{
 			Texture2D existingTexture = null;
-			if (ExistingTexture != null && Atlases.Count == 0)
+			if (fontSystem.ExistingTexture != null && fontSystem.Atlases.Count == 0)
 			{
-				existingTexture = ExistingTexture;
+				existingTexture = fontSystem.ExistingTexture;
 			}
 
 			FontAtlas _newAtlas = new FontAtlas(textureWidth, textureHeight, 256, existingTexture);
 		
 			// If existing texture is used, mark existing used rect as used
-			if (existingTexture != null && !ExistingTextureUsedSpace.IsEmpty)
+			if (existingTexture != null && !fontSystem.ExistingTextureUsedSpace.IsEmpty)
 			{
-				if (!_newAtlas.AddSkylineLevel(0, ExistingTextureUsedSpace.X, ExistingTextureUsedSpace.Y, ExistingTextureUsedSpace.Width, ExistingTextureUsedSpace.Height))
+				if (!_newAtlas.AddSkylineLevel(0, fontSystem.ExistingTextureUsedSpace.X, fontSystem.ExistingTextureUsedSpace.Y, fontSystem.ExistingTextureUsedSpace.Width, fontSystem.ExistingTextureUsedSpace.Height))
 				{
-					throw new Exception(string.Format("Unable to specify existing texture used space: {0}", ExistingTextureUsedSpace));
+					throw new Exception(string.Format("Unable to specify existing texture used space: {0}", fontSystem.ExistingTextureUsedSpace));
 				}
 
 				// TODO: Clear remaining space
@@ -193,7 +193,8 @@ namespace FontStashSharp
 		{
 			if (_currentAtlas == null)
 			{
-				_currentAtlas = CreateNewAtlas(textureWidth, textureHeight);
+				Func<FontSystem, int, int, FontAtlas> createNewAtlas = _settings.CreateNewAtlas ?? CreateNewAtlas;
+				_currentAtlas = createNewAtlas(this, textureWidth, textureHeight);
 
 				if (_currentAtlas == null)
 				{

--- a/src/FontStashSharp/FontSystemDefaults.cs
+++ b/src/FontStashSharp/FontSystemDefaults.cs
@@ -96,5 +96,7 @@ namespace FontStashSharp
 		public static int? DefaultCharacter { get; set; } = ' ';
 
 		public static int TextStyleLineHeight { get; set; } = 2;
+
+		public static Func<FontSystem, int, int, FontAtlas> CreateNewAtlas { get; set; }
 	}
 }

--- a/src/FontStashSharp/FontSystemSettings.cs
+++ b/src/FontStashSharp/FontSystemSettings.cs
@@ -143,6 +143,8 @@ namespace FontStashSharp
 		/// </summary>
 		public IFontLoader FontLoader { get; set; }
 
+		public Func<FontSystem, int, int, FontAtlas> CreateNewAtlas { get; set; }
+
 		public FontSystemSettings()
 		{
 			TextureWidth = FontSystemDefaults.TextureWidth;
@@ -152,6 +154,7 @@ namespace FontStashSharp
 			KernelWidth = FontSystemDefaults.KernelWidth;
 			KernelHeight = FontSystemDefaults.KernelHeight;
 			FontLoader = FontSystemDefaults.FontLoader;
+			CreateNewAtlas = FontSystemDefaults.CreateNewAtlas;
 		}
 
 		public FontSystemSettings Clone()
@@ -168,7 +171,8 @@ namespace FontStashSharp
 				KernelHeight = KernelHeight,
 				ExistingTexture = ExistingTexture,
 				ExistingTextureUsedSpace = ExistingTextureUsedSpace,
-				FontLoader = FontLoader
+				FontLoader = FontLoader,
+				CreateNewAtlas = CreateNewAtlas
 			};
 		}
 	}


### PR DESCRIPTION
Minimal example enabling using one font atlas for multiple fonts.
```
class SharedFontSystem : FontSystem
{
	public static FontAtlas m_sharedFontAtlas = null;
	public static readonly List<SharedFontSystem> SharedFontSystems = new List<SharedFontSystem>();
	public static int Size = 1024;

	public SharedFontSystem()
	{
		SharedFontSystems.Add(this);
	}

	protected override FontAtlas CreateNewAtlas(int textureWidth, int textureHeight)
	{
		if (ExistingTexture == null && Atlases.Count == 0)
		{
			m_sharedFontAtlas ??= base.CreateNewAtlas(Size, Size);
			return m_sharedFontAtlas;
		}
		return base.CreateNewAtlas(textureWidth, textureHeight);
	}

	public static void ResetAll()
	{
		m_sharedFontAtlas = null;
		foreach (SharedFontSystem sfs in SharedFontSystems)
		{
			sfs.Reset();
		}
	}
}
```