### PR TITLE
Updates FNA.Core csproj file from net7.0 to net8.0

### DIFF
--- a/src/XNA/FontStashSharp.FNA.Core.csproj
+++ b/src/XNA/FontStashSharp.FNA.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>FontStashSharp.FNA</PackageId>
     <AssemblyName>FontStashSharp.FNA</AssemblyName>
     <Description>FontStashSharp for FNA.Core</Description>


### PR DESCRIPTION
Recently the dotnet core version of FNA was updated from net7.0 over to net8.0, breaking compatibility with the FNA.Core csproj file as seen in the first screenshot below. This PR updates the FNA.Core csproj file to use net8.0 instead of net7.0. After upgrading over to net8.0, the library still works as intended based on second screenshot below.

<img width="570" alt="image" src="https://github.com/FontStashSharp/FontStashSharp/assets/57515252/8fd10072-034e-4041-93c5-cd215ddab0ff">

<img width="880" alt="image" src="https://github.com/FontStashSharp/FontStashSharp/assets/57515252/0512753e-beab-4ac8-8668-c6adcad57a1f">
