### PR TITLE
Fixes crash bug when parsing negative parameter values on certain computers

### DIFF
--- a/src/FontStashSharp/RichText/LayoutBuilder.cs
+++ b/src/FontStashSharp/RichText/LayoutBuilder.cs
@@ -200,7 +200,7 @@ namespace FontStashSharp.RichText
 			}
 
 			var parameters = _text.Substring(startPos.Value, endPos - startPos.Value);
-			return int.Parse(parameters);
+			return int.Parse(parameters, CultureInfo.InvariantCulture);
 		}
 
 		private bool ProcessCommand(ref int i, ref ChunkInfo r, out bool chunkFilled)


### PR DESCRIPTION
When players run a game with Rich Text on a computer set to certain non-English cultures (specifically ones that use a different negative sign such as "sl-SI"), FontStashSharp will crash if any of the parameters for rich text are negative numbers. For example, the rich text string `/v[-18]` will crash on a Slovenian.

See: https://stackoverflow.com/a/77725457/3059182

This is my first time contributing here, please let me know if there's anything I can do to this PR to make it easier to work with. Thank you! :)