### PR TITLE
BMFont binary format

### DIFF
--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 #if MONOGAME || FNA
 using Microsoft.Xna.Framework;
@@ -122,9 +123,18 @@ namespace FontStashSharp
 				// xml
 				bmFont.LoadXml(data);
 			}
+			else if (data.StartsWith("info"))
+			{
+				// text
+				bmFont.LoadText(data);
+			}
 			else
 			{
-				bmFont.LoadText(data);
+				// binary (expects base64-encoded string)
+				using (var stream = new MemoryStream(Convert.FromBase64String(data)))
+				{
+					bmFont.LoadBinary(stream);
+				}
 			}
 
 			return bmFont;

--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 #if MONOGAME || FNA
 using Microsoft.Xna.Framework;


### PR DESCRIPTION
I noticed that the BMFont-related API uses data strings (not Stream) and doesn't support loading BMFont binary format at the moment. I added binary format support, a couple lines of code to `LoadBMFont` where it expects a Base64-encoded string. Base64 seems pretty universal and reasonably efficient without requiring custom encoding on the user's part. Alternatively, adding functions that accept Stream data would probably be the most efficient solution.