### PR TITLE
Inherit alpha of the color parameter of RTL

### DIFF
--- a/src/FontStashSharp/RichText/RichTextLayout.cs
+++ b/src/FontStashSharp/RichText/RichTextLayout.cs
@@ -389,7 +389,7 @@ namespace FontStashSharp.RichText
 					var chunkColor = color;
 					if (!IgnoreColorCommand && chunk.Color != null)
 					{
-						chunkColor = chunk.Color.Value;
+						chunkColor = chunk.Color.Value * (color.A / 255f);
 					}
 
 					chunk.Draw(_renderContext, pos + new Vector2(0, chunk.VerticalOffset), chunkColor);


### PR DESCRIPTION
Add the possibility to apply an alpha on the color which is given as a command on a Rich Text.