### PR TITLE
Dispose atlas textures

### DIFF
--- a/src/FontStashSharp/FontSystem.cs
+++ b/src/FontStashSharp/FontSystem.cs
@@ -95,10 +95,13 @@ namespace FontStashSharp
 				_fontSources.Clear();
 			}
 
-			foreach (var atlas in Atlases)
-				atlas.Texture?.Dispose();
+			if (Atlases != null)
+			{
+				foreach (var atlas in Atlases)
+					atlas.Texture?.Dispose();
+				Atlases.Clear();
+			}
 
-			Atlases?.Clear();
 			SetFontAtlas(null);
 			_fonts.Clear();
 		}

--- a/src/FontStashSharp/FontSystem.cs
+++ b/src/FontStashSharp/FontSystem.cs
@@ -95,6 +95,9 @@ namespace FontStashSharp
 				_fontSources.Clear();
 			}
 
+			foreach (var atlas in Atlases)
+				atlas.Texture?.Dispose();
+
 			Atlases?.Clear();
 			SetFontAtlas(null);
 			_fonts.Clear();


### PR DESCRIPTION
I noticed a warning log in FNA because a texture did not get disposed. And I figured out it was the atlas texture.
So dispose atlas textures when disposing FontSystem.